### PR TITLE
#54 - feat: 구매 페이지 작업

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -60,6 +60,7 @@
       }
     ],
     "@typescript-eslint/no-shadow": "off",
-    "import/no-extraneous-dependencies": "off"
+    "import/no-extraneous-dependencies": "off",
+    "consistent-return": "off"
   }
 }

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -41,7 +41,7 @@ const Router = () => {
             }
           />
           <Route path="/cart" element={<Cart />} />
-          <Route path="/purchase" element={<Purchase />} />
+          <Route path="/purchase/:productId" element={<Purchase />} />
           <Route
             path="/mypage"
             element={

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -10,6 +10,7 @@ import Mypage from "@pages/MyPage";
 import MyAccount from "@pages/MyPage/MyAccount";
 import MyInfo from "@pages/MyPage/MyInfo";
 import MyOrder from "@pages/MyPage/MyOrder";
+import Purchase from "@pages/Purchase";
 import Shop from "@pages/Shop";
 import Signup from "@pages/Signup";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
@@ -40,6 +41,7 @@ const Router = () => {
             }
           />
           <Route path="/cart" element={<Cart />} />
+          <Route path="/purchase" element={<Purchase />} />
           <Route
             path="/mypage"
             element={

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -98,21 +98,29 @@ export const login = (email: string, password: string) => {
   return res;
 };
 
-// 로그아웃
-export const logout: AuthFn = async (token) => {
-  try {
-    const res = await client("/auth/logout", {
-      method: "post",
-    });
-
-    return res.data;
-  } catch (error) {
-    if (error instanceof AxiosError) {
-      console.log(error.message);
-    }
-    return false;
-  }
+export const logout = () => {
+  const res = client({
+    method: "post",
+    url: "/auth/logout",
+  });
+  return res;
 };
+
+// 로그아웃
+// export const logout: AuthFn = async (token) => {
+//   try {
+//     const res = await client("/auth/logout", {
+//       method: "post",
+//     });
+
+//     return res.data;
+//   } catch (error) {
+//     if (error instanceof AxiosError) {
+//       console.log(error);
+//     }
+//     return false;
+//   }
+// };
 
 // 정보 수정
 export const editInfo: EditAuthFn = async (

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -87,7 +87,7 @@ export const signUp: AuthFn = async (
 // };
 
 export const login = (email: string, password: string) => {
-  return client({
+  const res = client({
     method: "post",
     url: "/auth/login",
     data: {
@@ -95,6 +95,7 @@ export const login = (email: string, password: string) => {
       password,
     },
   });
+  return res;
 };
 
 // 로그아웃

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -67,23 +67,34 @@ export const signUp: AuthFn = async (
 };
 
 // 로그인
-export const login: AuthFn = async (email, password) => {
-  try {
-    const res = await client("/auth/login", {
-      method: "post",
-      data: {
-        email,
-        password,
-      },
-    });
+// export const login: AuthFn = async (email, password) => {
+//   try {
+//     const res = await client("/auth/login", {
+//       method: "post",
+//       data: {
+//         email,
+//         password,
+//       },
+//     });
 
-    return res.data;
-  } catch (error) {
-    if (error instanceof AxiosError) {
-      console.log(error.message);
-    }
-    return false;
-  }
+//     return res.data;
+//   } catch (error) {
+//     if (error instanceof AxiosError) {
+//       console.log(error.message);
+//     }
+//     return false;
+//   }
+// };
+
+export const login = (email: string, password: string) => {
+  return client({
+    method: "post",
+    url: "/auth/login",
+    data: {
+      email,
+      password,
+    },
+  });
 };
 
 // 로그아웃

--- a/src/api/core/api.ts
+++ b/src/api/core/api.ts
@@ -9,13 +9,13 @@ const axiosConfig: AxiosRequestConfig = {
     username: import.meta.env.VITE_API_USERNAME,
   },
 };
-const { accessToken } = JSON.parse(
-  JSON.parse(localStorage.getItem("persist:root") as string).auth,
-);
+
 export const client = axios.create(axiosConfig);
 
 client.interceptors.request.use((config) => {
-  console.log(accessToken);
+  const { accessToken } = JSON.parse(
+    JSON.parse(localStorage.getItem("persist:root") as string).auth,
+  );
   if (!config.headers) return config;
 
   if (accessToken !== null) {

--- a/src/api/product.ts
+++ b/src/api/product.ts
@@ -1,0 +1,13 @@
+import { AxiosError } from "axios";
+import { client } from "./core/api";
+
+// 제품 구매
+export const purchase = async (productId: string, accountId: string) => {
+  return client("/products/buy", {
+    method: "POST",
+    data: {
+      productId,
+      accountId,
+    },
+  });
+};

--- a/src/api/product.ts
+++ b/src/api/product.ts
@@ -11,3 +11,23 @@ export const purchase = async (productId: string, accountId: string) => {
     },
   });
 };
+
+// 제품 구매 확정
+export const cfmPurchase = async (detailId: string) => {
+  return client("/products/ok", {
+    method: "POST",
+    data: {
+      detailId,
+    },
+  });
+};
+
+// 제품 구매 취소
+export const cancelPurchase = async (detailId: string) => {
+  return client("/products/cancel", {
+    method: "POST",
+    data: {
+      detailId,
+    },
+  });
+};

--- a/src/api/product.ts
+++ b/src/api/product.ts
@@ -1,5 +1,5 @@
 import { AxiosError } from "axios";
-import { client, client } from "./core/api";
+import { client } from "./core/api";
 
 // 제품 구매
 export const purchase = async (productId: string, accountId: string) => {

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,6 +1,7 @@
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import authReducer from "features/authSlice";
 import cartReducer from "features/cartSlice";
+import purchaseReducer from "features/purchaseSlice";
 import categoryReducer from "features/categorySlice";
 import toggleReducer from "features/toggleSlice";
 import { persistStore, persistReducer } from "redux-persist";
@@ -17,6 +18,7 @@ const rootReducer = combineReducers({
   categoryReducer,
   auth: authReducer,
   cart: cartReducer,
+  purchase: purchaseReducer,
 });
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);

--- a/src/features/purchaseSlice.ts
+++ b/src/features/purchaseSlice.ts
@@ -1,0 +1,35 @@
+import type { PayloadAction } from "@reduxjs/toolkit";
+import { createSlice } from "@reduxjs/toolkit";
+
+export interface InitialState {
+  id: string;
+  title: string;
+  price: number;
+  thumbnail: string;
+  quantity: number;
+}
+const initialState: InitialState = {
+  id: "",
+  title: "",
+  price: 0,
+  thumbnail: "",
+  quantity: 0,
+};
+
+const purchaseSlice = createSlice({
+  name: "purchase",
+  initialState,
+  reducers: {
+    purchaseAction: (state, action: PayloadAction<InitialState>) => {
+      state.id = action.payload.id;
+      state.title = action.payload.title;
+      state.price = action.payload.price;
+      state.thumbnail = action.payload.thumbnail;
+      state.quantity = action.payload.quantity;
+    },
+    reset: (state) => initialState,
+  },
+});
+
+export default purchaseSlice.reducer;
+export const { purchaseAction, reset } = purchaseSlice.actions;

--- a/src/pages/Cart/index.tsx
+++ b/src/pages/Cart/index.tsx
@@ -11,22 +11,13 @@ import {
   decrementQuantity,
   incrementQuantity,
 } from "features/cartSlice";
+import { getTotal } from "utils/getTotal";
 
 interface Props {}
 const Cart = (props: Props) => {
   const [count, setCount] = useState(1);
   const { cart } = useAppSelector((state) => state);
   const dispatch = useAppDispatch();
-  const getTotal = () => {
-    let totalQuantity = 0;
-    let totalPrice = 0;
-    cart.forEach((item) => {
-      totalQuantity += item.quantity;
-      totalPrice += item.price * item.quantity;
-    });
-
-    return { totalQuantity, totalPrice };
-  };
 
   const onIncrement = (item: InitialState) => {
     console.log("clicked");
@@ -43,7 +34,7 @@ const Cart = (props: Props) => {
   return (
     <Container>
       <h4>
-        장바구니 <span>{getTotal().totalQuantity || 0}</span>
+        장바구니 <span>{getTotal(cart).totalQuantity || 0}</span>
       </h4>
 
       <CartWrapper>
@@ -90,9 +81,11 @@ const Cart = (props: Props) => {
       </CartWrapper>
       <Total>
         <div>합계</div>
-        <div>{getTotal().totalPrice.toLocaleString()} 원</div>
+        <div>{getTotal(cart).totalPrice.toLocaleString()} 원</div>
       </Total>
-      <Button>주문하기</Button>
+      <Link to="/purchase/cart">
+        <Button>주문하기</Button>
+      </Link>
     </Container>
   );
 };

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -3,13 +3,16 @@ import { useQuery } from "@tanstack/react-query";
 import { getProduct } from "api/product";
 import { useAppDispatch, useAppSelector } from "app/hooks";
 import { addToCart } from "features/cartSlice";
-import { useState } from "react";
-import { useParams } from "react-router-dom";
+import { purchaseAction } from "features/purchaseSlice";
+import { useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
 
 const Detail = () => {
   const [quantity, setQuantity] = useState(1);
   const { productId } = useParams();
+  const navigate = useNavigate();
+  const { purchase } = useAppSelector((state) => state);
 
   const { data: product, isLoading } = useQuery({
     queryKey: ["product"],
@@ -38,6 +41,26 @@ const Detail = () => {
       }),
     );
   };
+
+  const handleClickPurchase = () => {
+    dispatch(
+      purchaseAction({
+        id,
+        price,
+        quantity,
+        thumbnail,
+        title,
+      }),
+    );
+
+    // navigate(`/purchase/${purchase.id}`);
+  };
+
+  console.log(purchase);
+
+  useEffect(() => {
+    if (purchase.id === productId) navigate(`/purchase/${purchase.id}`);
+  }, [navigate, purchase.id, productId]);
 
   if (isLoading) return <div>loading...</div>;
   const { id, title, price, description, thumbnail, tags, photo } = product!;
@@ -78,7 +101,11 @@ const Detail = () => {
           </PriceWrapper>
 
           <BuyBtnWrapper>
-            <Button type="button" primary="primary" onClick={() => purchase()}>
+            <Button
+              type="button"
+              primary="primary"
+              onClick={handleClickPurchase}
+            >
               구매하기
             </Button>
             <Button type="button" onClick={handleClickCart}>

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -1,4 +1,5 @@
 import { tablet } from "@global/responsive";
+import { purchase } from "api/product";
 import { useAppDispatch, useAppSelector } from "app/hooks";
 import { addToCart } from "features/cartSlice";
 import { useState } from "react";
@@ -72,7 +73,7 @@ const Detail = () => {
           </PriceWrapper>
 
           <BuyBtnWrapper>
-            <Button type="button" primary="primary">
+            <Button type="button" primary="primary" onClick={() => purchase()}>
               구매하기
             </Button>
             <Button type="button" onClick={handleClickCart}>

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -19,8 +19,6 @@ const schema = yup.object().shape({
 
 const Login = () => {
   const dispatch = useAppDispatch();
-  // const [isLoading, setIsLoading] = useState(false);
-
   const navigate = useNavigate();
   const {
     register,
@@ -31,14 +29,16 @@ const Login = () => {
   });
 
   const onSubmit = async (data: FieldValues) => {
-    // setIsLoading(true);
     const { email, password } = data;
     try {
       const res = await login(email, password);
-      if (res.accessToken) {
-        // 모달을 이용해서 유저에게 정보 알리기
-        dispatch(setUser(res));
-        navigate("/");
+      if (res.data.accessToken) {
+        toast.success("로그인이 성공하였습니다", {
+          onClose: () => {
+            dispatch(setUser(res.data));
+            navigate("/");
+          },
+        });
       }
     } catch (error) {
       if (error instanceof AxiosError) {
@@ -72,18 +72,14 @@ const Login = () => {
       </PwdContainer>
       <BtnContainer>
         <Button type="submit">로그인 하기</Button>
-        <Button
-          type="button"
-          signup
-          onClick={() => {
-            navigate("/signup");
-          }}
-        >
-          회원가입 하기
-        </Button>
+        <Link to="/signup">
+          <Button type="button" signup>
+            회원가입 하기
+          </Button>
+        </Link>
       </BtnContainer>
       <ToastContainer
-        position="bottom-right"
+        position="top-center"
         autoClose={3000}
         hideProgressBar={false}
         newestOnTop={false}

--- a/src/pages/MyPage/MyInfo.tsx
+++ b/src/pages/MyPage/MyInfo.tsx
@@ -52,7 +52,8 @@ const MyInfo = () => {
 
   const handleLogout = async () => {
     const res = await logout();
-    if (res) {
+    console.log(res.data);
+    if (res.data) {
       dispatch(logOutAction());
       navigate("/");
     }

--- a/src/pages/Purchase/index.tsx
+++ b/src/pages/Purchase/index.tsx
@@ -1,0 +1,174 @@
+import Button from "@components/Button";
+import { tablet } from "@global/responsive";
+import { MdClose } from "react-icons/md";
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+
+const Purchase = () => {
+  return (
+    <Container>
+      <h4>
+        주문 목록 <span>몇 개</span>
+      </h4>
+
+      <PurchaseWrapper>
+        <PurchaseItem>
+          <div className="img-wrapper">
+            <Link to="/shop/abc">
+              <img
+                src="https://w.namu.la/s/ce183abef5e87594e9b0c182844ef87ad1679448ae06239ae8e4db1004c577a9dd67d3048532f18f13937fe4ef96e487abb8166b7afa7d4c07ff9eb8cbec249ce620af833f563f63dacfd0fd04228027"
+                alt="이미지"
+              />{" "}
+            </Link>
+          </div>
+          <DetailWrapper>
+            <div className="price-detail">
+              <p />
+              <BtnWrapper>
+                <p>몇개</p>
+              </BtnWrapper>
+              <div>얼마</div>
+            </div>
+            <div>
+              <DeleteBtn type="button">
+                <MdClose />
+              </DeleteBtn>
+              <button className="delete-btn-pc" type="button">
+                삭제하기
+              </button>
+            </div>
+          </DetailWrapper>
+        </PurchaseItem>
+      </PurchaseWrapper>
+
+      <ShippingContainer>
+        <h4>배송지 정보</h4>
+        <div>
+          <label htmlFor="name">수령인</label>
+          <input type="text" id="name" placeholder="수령인" />
+        </div>
+        <div>
+          <label htmlFor="address">배송지</label>
+          <input type="text" id="address" placeholder="배송지" />
+        </div>
+        <div>
+          <label htmlFor="mobile">연락처</label>
+          <input type="text" id="mobile" placeholder="연락처" />
+        </div>
+      </ShippingContainer>
+      <Button> 총 얼마 주문하기</Button>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  padding: 0 1rem 2.25rem;
+
+  h4 {
+    font-size: 1.5rem;
+    margin-top: 3.5rem;
+  }
+
+  ${tablet({
+    maxWidth: "750px",
+    marginInline: "auto",
+  })}
+`;
+
+const PurchaseWrapper = styled.ul`
+  margin: 1.5rem 0;
+  border-top: 1px solid;
+`;
+
+const PurchaseItem = styled.li`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid;
+  /* gap: 1.25rem; */
+  position: relative;
+  .img-wrapper {
+    width: 30%;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  }
+  .price-detail {
+    display: flex;
+    flex-direction: column;
+    align-items: start;
+    gap: 1rem;
+
+    ${tablet({
+      flexDirection: "row",
+      alignItems: "center",
+      gap: "1.25rem",
+    })}
+  }
+  .delete-btn-pc {
+    font-family: inherit;
+    display: none;
+    font-weight: 600;
+    ${tablet({
+      display: "block",
+    })}
+  }
+`;
+
+const DetailWrapper = styled.div`
+  display: flex;
+  gap: 2.5rem;
+  ${tablet({
+    flexDirection: "column",
+    gap: "1rem",
+  })}
+`;
+
+const BtnWrapper = styled.div`
+  align-items: center;
+  padding: 0.5rem;
+  /* width: 28px;
+  height: 28px; */
+  text-align: center;
+  font-size: 0.875rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const DeleteBtn = styled.button`
+  position: absolute;
+  /* display: flex;
+  align-items: start; */
+  height: 100%;
+  top: -42px;
+  right: 0;
+  ${tablet({
+    display: "none",
+  })}
+`;
+
+const ShippingContainer = styled.form`
+  margin-bottom: 20px;
+  label {
+    line-height: 2.5rem;
+  }
+  input {
+    display: block;
+    border: 1px solid var(--primary-color);
+    width: 100%;
+    line-height: 10px;
+    padding: 0.625rem 0.9375rem;
+    color: var(--primary-color);
+  }
+  p {
+    color: red;
+    font-size: 10px;
+    margin-top: 0.25rem;
+  }
+`;
+
+export default Purchase;

--- a/src/pages/Purchase/index.tsx
+++ b/src/pages/Purchase/index.tsx
@@ -3,8 +3,48 @@ import { tablet } from "@global/responsive";
 import { MdClose } from "react-icons/md";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
+import DaumPostcode from "react-daum-postcode";
+import { useEffect, useRef, useState } from "react";
+import { colors } from "constants/color";
 
 const Purchase = () => {
+  const [openPostcode, setOpenPostcode] = useState<boolean>(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const [zipcode, setZipcode] = useState("");
+  const [address, setAddress] = useState("");
+
+  const handle = {
+    // 버튼 클릭 이벤트
+    clickButton: () => {
+      setOpenPostcode((current) => !current);
+    },
+
+    // 주소 선택 이벤트
+    selectAddress: (data: any) => {
+      console.log(`
+            주소: ${data.address},
+            우편번호: ${data.zonecode}
+        `);
+      setZipcode(data.zonecode);
+      setAddress(data.address);
+      setOpenPostcode(false);
+    },
+  };
+
+  // 모달 오버레이에서 스크롤 방지
+  useEffect(() => {
+    if (openPostcode) {
+      document.body.style.cssText = `
+      overflow:hidden;
+      `;
+      return () => {
+        const scrollY = document.body.style.top;
+        document.body.style.cssText = "";
+        window.scrollTo(0, parseInt(scrollY || "0", 10) * -1);
+      };
+    }
+  }, [openPostcode]);
+
   return (
     <Container>
       <h4>
@@ -47,19 +87,111 @@ const Purchase = () => {
           <label htmlFor="name">수령인</label>
           <input type="text" id="name" placeholder="수령인" />
         </div>
-        <div>
-          <label htmlFor="address">배송지</label>
-          <input type="text" id="address" placeholder="배송지" />
-        </div>
+
         <div>
           <label htmlFor="mobile">연락처</label>
           <input type="text" id="mobile" placeholder="연락처" />
+        </div>
+        <div>
+          <label htmlFor="address">배송지</label>
+          <AddressWrapper>
+            <input
+              type="text"
+              id="address"
+              placeholder="우편번호"
+              value={zipcode}
+              readOnly
+            />
+            <AddressBtn type="button" onClick={handle.clickButton}>
+              검색하기
+            </AddressBtn>
+          </AddressWrapper>
+          <AddressWrapper>
+            <input
+              type="text"
+              id="address"
+              placeholder="주소"
+              value={address}
+              readOnly
+            />
+            <input
+              type="text"
+              id="address"
+              placeholder="상세주소를 직접 입력해주세요"
+            />
+          </AddressWrapper>
+
+          {openPostcode && (
+            <Overlay>
+              <ModalWrap ref={modalRef}>
+                <DaumPostcode
+                  onComplete={handle.selectAddress} // 값을 선택할 경우 실행되는 이벤트
+                  autoClose // 값을 선택할 경우 사용되는 DOM을 제거하여 자동 닫힘 설정
+                  // defaultQuery="서울특별시 강남구 역삼동 826-21" // 팝업을 열때 기본적으로 입력되는 검색어
+                />
+                <Button
+                  type="button"
+                  onClick={() => {
+                    setOpenPostcode(false);
+                  }}
+                >
+                  취소하기
+                </Button>
+              </ModalWrap>
+            </Overlay>
+          )}
         </div>
       </ShippingContainer>
       <Button> 총 얼마 주문하기</Button>
     </Container>
   );
 };
+
+const Overlay = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.2);
+  z-index: 9999;
+  display: grid;
+  place-items: center;
+`;
+
+const ModalWrap = styled.div`
+  width: 400px;
+  height: fit-content;
+  background-color: #fff;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  button {
+    position: absolute;
+    bottom: 0;
+    margin-bottom: 0;
+    width: 400px;
+    border: none;
+    background-color: var(--primary-color);
+    color: white;
+  }
+`;
+
+const AddressWrapper = styled.div`
+  display: flex;
+  gap: 10px;
+  margin-bottom: 10px;
+  input {
+    gap: 10px;
+  }
+`;
+const AddressBtn = styled.button`
+  border: 1px solid var(--primary-color);
+  width: 200px;
+`;
 
 const Container = styled.div`
   padding: 0 1rem 2.25rem;
@@ -152,7 +284,7 @@ const DeleteBtn = styled.button`
 `;
 
 const ShippingContainer = styled.form`
-  margin-bottom: 20px;
+  margin-bottom: 3.5rem;
   label {
     line-height: 2.5rem;
   }

--- a/src/utils/getTotal.ts
+++ b/src/utils/getTotal.ts
@@ -1,0 +1,12 @@
+import type { InitialState } from "features/cartSlice";
+
+export const getTotal = (cart: InitialState[]) => {
+  let totalQuantity = 0;
+  let totalPrice = 0;
+  cart.forEach((item) => {
+    totalQuantity += item.quantity;
+    totalPrice += item.price * item.quantity;
+  });
+
+  return { totalQuantity, totalPrice };
+};


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
- #48 
- #50 
- #54  

## 작업 내용 (변경 사항)
- eslint 에 `consistent-return` 을 추가하였습니다
- 장바구니, 상세 페이지에서 `구매하기`를 눌렀을 때 이동하는 구매 페이지를 만들고 라우팅 하였습니다.
- 장바구니 목록을 한꺼번에 구매할 수 있도록 리덕스로 아이템을 관리합니다.
- 아이템 목록 길이를 반환하는 함수가 재사용되어  `utils` 폴더에 따로 빼내었습니다.
- 상세 페이지에서 구매하기 버튼을 눌렀을 시 제대로 패치가 안되는 작업을 **처리 중**입니다.

## 리뷰 요청 사항
-
