### PR TITLE
#63 - feat: 구매 내역 페이지 리팩토링

### DIFF
--- a/src/lib/hooks/useCancelMutation.ts
+++ b/src/lib/hooks/useCancelMutation.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { cancelPurchase } from "api/product";
+import React from "react";
+
+const useCancelMutation = () => {
+  const queryClient = useQueryClient();
+  const { mutate: cancelMutation } = useMutation({
+    mutationFn: (id: string) => cancelPurchase(id),
+    onSuccess(data, variables, context) {
+      queryClient.invalidateQueries();
+    },
+    onError(error, variables, context) {
+      alert("이미 구매 완료한 제품은 취소할 수 없습니다.");
+    },
+  });
+
+  return { cancelMutation };
+};
+
+export default useCancelMutation;

--- a/src/lib/hooks/useConfirmMutation.ts
+++ b/src/lib/hooks/useConfirmMutation.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { cfmPurchase } from "api/product";
+import React from "react";
+
+const useConfirmMutation = () => {
+  const queryClient = useQueryClient();
+  const { mutate: confirmMutation } = useMutation({
+    mutationFn: (id: string) => cfmPurchase(id),
+    onSuccess(data, variables, context) {
+      queryClient.invalidateQueries();
+    },
+    onError(error, variables, context) {
+      alert("구매 확정에 실패했습니다.");
+    },
+  });
+
+  return { confirmMutation };
+};
+
+export default useConfirmMutation;

--- a/src/pages/MyPage/MyOrder.tsx
+++ b/src/pages/MyPage/MyOrder.tsx
@@ -3,6 +3,7 @@ import { cfmPurchase, getPurchaseHistory, cancelPurchase } from "api/product";
 import { toast, ToastContainer } from "react-toastify";
 import styled from "styled-components";
 import { tablet } from "../../global/responsive";
+import { isCancel } from "axios";
 
 const MyOrder = () => {
   const queryClient = useQueryClient();
@@ -53,7 +54,9 @@ const MyOrder = () => {
                 </ItemInfoContainer>
               </ItemInfoWrapper>
               <ConfirmOrderContainer>
-                {item.done ? (
+                {item.isCanceled ? (
+                  ""
+                ) : item.done ? (
                   ""
                 ) : (
                   <Cfmbtn
@@ -63,7 +66,9 @@ const MyOrder = () => {
                     확정
                   </Cfmbtn>
                 )}
-                {item.done ? (
+                {item.isCanceled ? (
+                  ""
+                ) : item.done ? (
                   ""
                 ) : (
                   <Cfmbtn

--- a/src/pages/MyPage/MyOrder.tsx
+++ b/src/pages/MyPage/MyOrder.tsx
@@ -1,8 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { cfmPurchase, getPurchaseHistory, cancelPurchase } from "api/product";
-
-import { useAppSelector } from "app/hooks";
-import { useEffect, useState } from "react";
 import { toast, ToastContainer } from "react-toastify";
 import styled from "styled-components";
 import { tablet } from "../../global/responsive";
@@ -14,12 +11,14 @@ const MyOrder = () => {
     queryFn: getPurchaseHistory,
     refetchOnWindowFocus: false,
   });
-  console.log(history);
 
   const confirmMutation = useMutation({
     mutationFn: (id: string) => cfmPurchase(id),
     onSuccess(data, variables, context) {
       queryClient.invalidateQueries();
+    },
+    onError(error, variables, context) {
+      alert("구매 확정에 실패했습니다.");
     },
   });
 
@@ -29,10 +28,9 @@ const MyOrder = () => {
       // queryClient.invalidateQueries();
     },
     onError(error, variables, context) {
-      toast.error("이미 구매 완료한 제품은 취소할 수 없습니다.");
+      alert("이미 구매 완료한 제품은 취소할 수 없습니다.");
     },
   });
-
   return (
     <Container>
       {history?.map((item) => {
@@ -55,18 +53,26 @@ const MyOrder = () => {
                 </ItemInfoContainer>
               </ItemInfoWrapper>
               <ConfirmOrderContainer>
-                <Cfmbtn
-                  type="button"
-                  onClick={() => confirmMutation.mutate(item.detailId)}
-                >
-                  확정
-                </Cfmbtn>
-                <Cfmbtn
-                  type="button"
-                  onClick={() => cancelMutation.mutate(item.detailId)}
-                >
-                  취소
-                </Cfmbtn>
+                {item.done ? (
+                  ""
+                ) : (
+                  <Cfmbtn
+                    type="button"
+                    onClick={() => confirmMutation.mutate(item.detailId)}
+                  >
+                    확정
+                  </Cfmbtn>
+                )}
+                {item.done ? (
+                  ""
+                ) : (
+                  <Cfmbtn
+                    type="button"
+                    onClick={() => cancelMutation.mutate(item.detailId)}
+                  >
+                    구매 취소
+                  </Cfmbtn>
+                )}
               </ConfirmOrderContainer>
             </Wrapper>
           </ItemContainer>
@@ -176,8 +182,8 @@ const Cfmbtn = styled.button`
   min-width: 60px;
   flex: 1;
   :hover {
-    color: var(--primary-color);
-    border: 1.5px solid var(--primary-color);
+    color: var(--pramary-color);
+    border: 1px solid var(--primary-color);
   }
   ${tablet({
     padding: "6px 14px",

--- a/src/pages/MyPage/MyOrder.tsx
+++ b/src/pages/MyPage/MyOrder.tsx
@@ -1,37 +1,21 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { cfmPurchase, getPurchaseHistory, cancelPurchase } from "api/product";
-import { toast, ToastContainer } from "react-toastify";
+import { useQuery } from "@tanstack/react-query";
+import { getPurchaseHistory } from "api/product";
+import { ToastContainer } from "react-toastify";
 import styled from "styled-components";
 import { tablet } from "../../global/responsive";
-import { isCancel } from "axios";
+import useConfirmMutation from "lib/hooks/useConfirmMutation";
+import useCancelMutation from "lib/hooks/useCancelMutation";
 
 const MyOrder = () => {
-  const queryClient = useQueryClient();
+  const { confirmMutation } = useConfirmMutation();
+  const { cancelMutation } = useCancelMutation();
+
   const { data: history } = useQuery({
     queryKey: ["history"],
     queryFn: getPurchaseHistory,
     refetchOnWindowFocus: false,
   });
 
-  const confirmMutation = useMutation({
-    mutationFn: (id: string) => cfmPurchase(id),
-    onSuccess(data, variables, context) {
-      queryClient.invalidateQueries();
-    },
-    onError(error, variables, context) {
-      alert("구매 확정에 실패했습니다.");
-    },
-  });
-
-  const cancelMutation = useMutation({
-    mutationFn: (id: string) => cancelPurchase(id),
-    onSuccess(data, variables, context) {
-      // queryClient.invalidateQueries();
-    },
-    onError(error, variables, context) {
-      alert("이미 구매 완료한 제품은 취소할 수 없습니다.");
-    },
-  });
   return (
     <Container>
       {history?.map((item) => {
@@ -61,7 +45,7 @@ const MyOrder = () => {
                 ) : (
                   <Cfmbtn
                     type="button"
-                    onClick={() => confirmMutation.mutate(item.detailId)}
+                    onClick={() => confirmMutation(item.detailId)}
                   >
                     확정
                   </Cfmbtn>
@@ -73,7 +57,7 @@ const MyOrder = () => {
                 ) : (
                   <Cfmbtn
                     type="button"
-                    onClick={() => cancelMutation.mutate(item.detailId)}
+                    onClick={() => cancelMutation(item.detailId)}
                   >
                     구매 취소
                   </Cfmbtn>

--- a/src/pages/MyPage/MyOrder.tsx
+++ b/src/pages/MyPage/MyOrder.tsx
@@ -38,29 +38,21 @@ const MyOrder = () => {
                 </ItemInfoContainer>
               </ItemInfoWrapper>
               <ConfirmOrderContainer>
-                {item.isCanceled ? (
-                  ""
-                ) : item.done ? (
-                  ""
-                ) : (
-                  <Cfmbtn
-                    type="button"
-                    onClick={() => confirmMutation(item.detailId)}
-                  >
-                    확정
-                  </Cfmbtn>
-                )}
-                {item.isCanceled ? (
-                  ""
-                ) : item.done ? (
-                  ""
-                ) : (
-                  <Cfmbtn
-                    type="button"
-                    onClick={() => cancelMutation(item.detailId)}
-                  >
-                    구매 취소
-                  </Cfmbtn>
+                {item.isCanceled || item.done ? null : (
+                  <>
+                    <Cfmbtn
+                      type="button"
+                      onClick={() => confirmMutation(item.detailId)}
+                    >
+                      확정
+                    </Cfmbtn>
+                    <Cfmbtn
+                      type="button"
+                      onClick={() => cancelMutation(item.detailId)}
+                    >
+                      구매 취소
+                    </Cfmbtn>
+                  </>
                 )}
               </ConfirmOrderContainer>
             </Wrapper>


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
- #63 

## 작업 내용 (변경 사항)
- 구매 확정/ 구매 취소한 아이템은 구매 확정/ 구매 취소 버튼이 사라집니다.
- mutate 함수를 분리하였습니다.

## 리뷰 요청 사항

